### PR TITLE
Update deps 2021-05-11

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -132,12 +132,16 @@ dependencies {
   implementation(deps.squareup.retrofit.moshi)
   implementation(deps.squareup.retrofit.retrofit)
   implementation(deps.squareup.retrofit.rxjava2)
+  implementation(deps.misc.jsr305)
 
   coreLibraryDesugaring(deps.android.desugarJdkLibs)
 
   kapt(deps.glide.compiler)
   kapt(deps.google.dagger.compiler)
   kapt(deps.squareup.moshi.compiler)
+
+  compileOnly(deps.misc.javaxInject)
+  compileOnly(deps.misc.jsr250)
 
   debugImplementation(deps.squareup.leakcanary)
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,8 +46,8 @@ allprojects {
     kotlinOptions {
       // allWarningsAsErrors = true // migrate ActivityTestRule to ActivityScenario
       jvmTarget = deps.versions.java.toString()
-      languageVersion = "1.4"
-      apiVersion = "1.4"
+      languageVersion = "1.5"
+      apiVersion = "1.5"
       freeCompilerArgs = freeCompilerArgs + listOf(
         "-progressive",
         "-Xjsr305=strict",
@@ -71,6 +71,7 @@ allprojects {
         add("-Xlint:-deprecation")       // Allow deprecations from Dagger 2
         add("-Xlint:-classfile")         // Ignore Java 8 method param meta data
         add("-Xlint:-unchecked")         // Dagger 2 unchecked issues
+        add("-Xlint:-cast")              // https://github.com/google/dagger/issues/2339
         add("-Werror")                   // Turn warnings into errors
       }
       encoding = "utf-8"

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -3,10 +3,10 @@ repositories {
 }
 
 plugins {
-  kotlin("jvm") version "1.4.21-2"
+  kotlin("jvm") version "1.5.0"
   `kotlin-dsl`
 }
 
 dependencies {
-  implementation(kotlin("stdlib-jdk8", version = "1.4.21-2"))
+  implementation(kotlin("stdlib-jdk8", version = "1.5.0"))
 }

--- a/buildSrc/src/main/java/dependencies.kt
+++ b/buildSrc/src/main/java/dependencies.kt
@@ -5,13 +5,13 @@ import org.gradle.api.JavaVersion
 object deps {
   object versions {
     const val androidGradle = "4.2.0"
-    const val kotlin = "1.4.21-2"
-    const val dagger = "2.28-alpha" // 2.29+, error: incompatible types: NonExistentClass cannot be converted to Annotation
-    const val okHttp = "4.9.0"
-    const val moshi = "1.11.0"
+    const val kotlin = "1.5.0"
+    const val dagger = "2.35.1"
+    const val okHttp = "4.9.1"
+    const val moshi = "1.12.0"
     const val retrofit = "2.9.0"
     const val espresso = "3.3.0"
-    const val glide = "4.11.0"
+    const val glide = "4.12.0"
     val java = JavaVersion.VERSION_1_8
   }
 
@@ -32,7 +32,7 @@ object deps {
     const val command = "com.novoda:gradle-android-command-plugin:2.1.0"
     const val dexcount = "com.getkeepsafe.dexcount:dexcount-gradle-plugin:2.1.0-RC01"
     const val apksize = "com.vanniktech:gradle-android-apk-size-plugin:0.4.0"
-    const val versions = "com.github.ben-manes:gradle-versions-plugin:0.36.0"
+    const val versions = "com.github.ben-manes:gradle-versions-plugin:0.38.0"
     const val ktlint = "org.jlleitschuh.gradle:ktlint-gradle:10.0.0"
     const val dagger = "com.google.dagger:hilt-android-gradle-plugin:${deps.versions.dagger}"
   }
@@ -61,12 +61,12 @@ object deps {
 
   object rxjava {
     const val rxandroid = "io.reactivex.rxjava2:rxandroid:2.1.1"
-    const val rxjava = "io.reactivex.rxjava2:rxjava:2.2.20"
+    const val rxjava = "io.reactivex.rxjava2:rxjava:2.2.21"
   }
 
   object squareup {
-    const val okio = "com.squareup.okio:okio:2.9.0"
-    const val leakcanary = "com.squareup.leakcanary:leakcanary-android:2.5"
+    const val okio = "com.squareup.okio:okio:2.10.0"
+    const val leakcanary = "com.squareup.leakcanary:leakcanary-android:2.7"
 
     object okhttp {
       const val okhttp = "com.squareup.okhttp3:okhttp:${versions.okHttp}"
@@ -89,7 +89,7 @@ object deps {
 
   object google {
     const val material = "com.google.android.material:material:1.2.1"
-    const val truth = "com.google.truth:truth:1.1"
+    const val truth = "com.google.truth:truth:1.1.2"
 
     object dagger {
       const val dagger = "com.google.dagger:hilt-android:${versions.dagger}"
@@ -104,13 +104,19 @@ object deps {
   }
 
   object test {
-    const val junit = "junit:junit:4.13.1"
-    const val robolectric = "org.robolectric:robolectric:4.4"
+    const val junit = "junit:junit:4.13.2"
+    const val robolectric = "org.robolectric:robolectric:4.5"
     const val reflections = "org.reflections:reflections:0.9.11" // 0.9.12+, Scanner SubTypesScanner was not configured
 
     object mockito {
-      const val inline = "org.mockito:mockito-inline:3.6.28"
+      const val inline = "org.mockito:mockito-inline:3.8.0"
       const val kotlin = "com.nhaarman.mockitokotlin2:mockito-kotlin:2.1.0"
     }
+  }
+
+  object misc {
+    const val javaxInject = "org.glassfish:javax.annotation:10.0-b28"
+    const val jsr250 = "javax.annotation:jsr250-api:1.0"
+    const val jsr305 = "com.google.code.findbugs:jsr305:3.0.2"
   }
 }


### PR DESCRIPTION
Update Kotlin to 1.5
Update `org.jetbrains.kotlin:kotlin-gradle-plugin` to `1.5`
Update `org.jetbrains.kotlin:kotlin-stdlib` to `1.5`
Update `com.google.dagger:hilt-android` to `2.35.1`
Update `com.google.dagger:hilt-android-compiler` to `2.35.1`
Update `com.squareup.okhttp3:okhttp` to `4.9.1`
Update `com.squareup.okhttp3:logging-interceptor` to `4.9.1`
Update `com.squareup.okhttp3:mockwebserver` to `4.9.1`
Update `com.squareup.moshi:moshi` to `1.12.0`
Update `com.squareup.moshi:moshi-adapters` to `1.12.0`
Update `com.squareup.moshi:moshi-kotlin-codegen` to `1.12.0`
Update `com.github.bumptech.glide:glide` to `4.12.0`
Update `com.github.bumptech.glide:compiler` to `4.12.0`
Update `com.github.bumptech.glide:okhttp3-integration:` to `4.12.0`
Update `com.github.ben-manes:gradle-versions-plugin` to `0.38.0`
Update `io.reactivex.rxjava2:rxjava` to `2.2.21`
Update `com.google.truth:truth` to `1.1.2`
Update `junit:junit` to `4.13.2`
Update `org.mockito:mockito-inline` to `3.8.0`