### PR TITLE
optimize plugins

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,15 +1,13 @@
-apply {
-  plugin("com.novoda.android-command")
-  plugin("com.getkeepsafe.dexcount")
-  plugin("com.vanniktech.android.apk.size")
-  plugin("org.jlleitschuh.gradle.ktlint")
-  plugin("dagger.hilt.android.plugin")
-}
-
 plugins {
   id("com.android.application")
   kotlin("android")
   kotlin("kapt")
+}
+
+apply {
+  plugin("com.novoda.android-command") // Plugin data not published
+  plugin("com.getkeepsafe.dexcount") // Plugin data not published
+  plugin("dagger.hilt.android.plugin") // NPlugin data not published
 }
 
 android {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,27 +13,25 @@ buildscript {
   }
 
   dependencies {
-    classpath(deps.plugin.gradle)
-    classpath(deps.plugin.kotlin)
-    classpath(deps.plugin.command)
-    classpath(deps.plugin.dexcount)
-    classpath(deps.plugin.apksize)
-    classpath(deps.plugin.versions)
-    classpath(deps.plugin.ktlint)
-    classpath(deps.plugin.dagger)
+    classpath(deps.plugin.command) // Plugin data not published
+    classpath(deps.plugin.dexcount) // Plugin data not published
+    classpath(deps.plugin.dagger) // Plugin data not published
   }
 }
 
-allprojects {
-  apply {
-    plugin("com.github.ben-manes.versions")
-  }
+plugins {
+  id("com.android.application") version "7.0.4" apply false
+  kotlin("android") version "1.6.10" apply false
+  id("org.jlleitschuh.gradle.ktlint") version "10.2.1"
+  id("com.github.ben-manes.versions") version "0.41.0"
+}
 
+allprojects {
   configurations.all {
     resolutionStrategy {
-      failOnVersionConflict()
-
       preferProjectModules()
+
+      enableDependencyVerification()
 
       eachDependency {
         when (requested.group) {
@@ -86,7 +84,7 @@ allprojects {
         "-Xstrict-java-nullability-assertions",
         // Enable new jvmdefault behavior
         // https://blog.jetbrains.com/kotlin/2020/07/kotlin-1-4-m3-generating-default-methods-in-interfaces/
-        "-Xjvm-default=all", // "-Xjvm-default=enable",
+        "-Xjvm-default=all",
         "-P",
         "plugin:androidx.compose.compiler.plugins.kotlin:suppressKotlinVersionCompatibilityCheck=true",
       )

--- a/buildSrc/src/main/java/dependencies.kt
+++ b/buildSrc/src/main/java/dependencies.kt
@@ -4,7 +4,6 @@ import org.gradle.api.JavaVersion
 
 object deps {
   object versions {
-    const val androidGradle = "7.0.4"
     const val kotlin = "1.6.10"
     const val kotlinx = "1.6.0"
     const val dagger = "2.40.5"
@@ -28,14 +27,9 @@ object deps {
   }
 
   object plugin {
-    const val gradle = "com.android.tools.build:gradle:${deps.versions.androidGradle}"
-    const val kotlin = "org.jetbrains.kotlin:kotlin-gradle-plugin:${deps.versions.kotlin}"
     const val command = "com.novoda:gradle-android-command-plugin:2.1.0"
     const val dexcount = "com.getkeepsafe.dexcount:dexcount-gradle-plugin:3.0.1"
-    const val apksize = "com.vanniktech:gradle-android-apk-size-plugin:0.4.0"
-    const val versions = "com.github.ben-manes:gradle-versions-plugin:0.41.0"
-    const val ktlint = "org.jlleitschuh.gradle:ktlint-gradle:10.2.1"
-    const val dagger = "com.google.dagger:hilt-android-gradle-plugin:${deps.versions.dagger}"
+    const val dagger = "com.google.dagger:hilt-android-gradle-plugin:${versions.dagger}"
   }
 
   object kotlin {


### PR DESCRIPTION
- Apply `com.android.tools.build:gradle` via `plugins` dsl
- Apply `org.jetbrains.kotlin:kotlin-gradle-plugin` via `plugins` dsl
- Apply `com.github.ben-manes:gradle-versions-plugin` via `plugins` dsl
- Apply `org.jlleitschuh.gradle:ktlint-gradle` via `plugins` dsl
- Removed `com.vanniktech:gradle-android-apk-size-plugin` since it is archived
- `com.google.dagger:hilt-android-gradle-plugin` still does not support `plugins` dsl - https://github.com/google/dagger/issues/2774, https://github.com/google/dagger/issues/3170
- `com.novoda:gradle-android-command-plugin` still does not support `plugins` dsl - https://github.com/novoda/gradle-android-command-plugin/issues/95
- `com.getkeepsafe.dexcount` - needs to publish latest to plugins.gradle - https://github.com/KeepSafe/dexcount-gradle-plugin/issues/427