### PR TITLE
use plugins dsl for dexcount

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,11 +2,11 @@ plugins {
   id("com.android.application")
   kotlin("android")
   kotlin("kapt")
+  id("com.getkeepsafe.dexcount") version "3.0.1"
 }
 
 apply {
   plugin("com.novoda.android-command") // Plugin data not published
-  plugin("com.getkeepsafe.dexcount") // Plugin data not published
   plugin("dagger.hilt.android.plugin") // NPlugin data not published
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,6 @@ buildscript {
 
   dependencies {
     classpath(deps.plugin.command) // Plugin data not published
-    classpath(deps.plugin.dexcount) // Plugin data not published
     classpath(deps.plugin.dagger) // Plugin data not published
   }
 }

--- a/buildSrc/src/main/java/dependencies.kt
+++ b/buildSrc/src/main/java/dependencies.kt
@@ -28,7 +28,6 @@ object deps {
 
   object plugin {
     const val command = "com.novoda:gradle-android-command-plugin:2.1.0"
-    const val dexcount = "com.getkeepsafe.dexcount:dexcount-gradle-plugin:3.0.1"
     const val dagger = "com.google.dagger:hilt-android-gradle-plugin:${versions.dagger}"
   }
 


### PR DESCRIPTION
Closes https://github.com/KeepSafe/dexcount-gradle-plugin/issues/427

```
$ gradlew countDebugDexMethods

> Task :app:countDebugDexMethods
Total methods in app-debug.apk: 80095 (122.22% used)
Total fields in app-debug.apk: 41965 (64.03% used)
Total classes in app-debug.apk: 10192 (15.55% used)
Methods remaining in app-debug.apk: 0
Fields remaining in app-debug.apk: 23570
Classes remaining in app-debug.apk: 55343

BUILD SUCCESSFUL in 9s
45 actionable tasks: 2 executed, 43 up-to-date
```